### PR TITLE
Релиз v2.1.2

### DIFF
--- a/BotFramework/Handlers/StepHandlers/TransitionHandler.cs
+++ b/BotFramework/Handlers/StepHandlers/TransitionHandler.cs
@@ -74,9 +74,13 @@ namespace BotFramework.Handlers.StepHandlers
         /// <param name="request">Запрос</param>
         public bool CanHandle(object request)
         {
+            if (!IsRunning)
+            {
+                return _head.CanHandle(request);
+            }
+
             var currentHandler = _handlersToExecute.Peek();
-            
-            return _head.CanHandle(request) || IsRunning && currentHandler.CanHandle(_previousRequest, request);
+            return currentHandler.CanHandle(_previousRequest, request);
         }
     }
 }


### PR DESCRIPTION
**Баг-фикс:**
В методе TransitionHandler.CanHandle() код получения текущего пошагового обработчика теперь располагается после проверки существования объектов в _handlersToExecute, потому что это постоянно генерировало исключение